### PR TITLE
chore: add terraform-driven branch protection setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,17 +8,23 @@
       "extensions": [
         "esbenp.prettier-vscode",
         "streetsidesoftware.code-spell-checker",
-        "openai.chatgpt"
+        "openai.chatgpt",
+        "hashicorp.terraform"
       ],
       "settings": {
         "editor.formatOnSave": true
       }
     }
   },
-  "forwardPorts": [8000],
+  "forwardPorts": [
+    8000
+  ],
   "portsAttributes": {
     "8000": {
       "label": "Zenn Preview"
     }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/terraform:1": {}
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 .DS_Store
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules
 .terraform/
 *.tfstate
 *.tfstate.backup
-*.tfvars
+terraform/terraform.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .terraform/
 *.tfstate
 *.tfstate.backup
+terraform/terraform.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ node_modules
 .terraform/
 *.tfstate
 *.tfstate.backup
-terraform/terraform.tfvars
+*.tfvars

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Zenn CLI を使って記事作成や公開フローを効率化するための�
 
 ## GitHub IaC
 
+- `repo` スコープを持つ PAT を発行し `export GITHUB_TOKEN=$(gh auth token)` などで Terraform から利用
+- 初回は `terraform/terraform.tfvars.example` を `terraform/terraform.tfvars` にコピーし、自分の `github_owner` と `repository_name` を設定
 - 実行フロー: `cd terraform && terraform init && terraform plan` で内容確認 → `terraform apply` で GitHub に反映
-
-- `export GITHUB_TOKEN=$(gh auth token)`

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Zenn CLI を使って記事作成や公開フローを効率化するための�
 - 画像は `articles/_posts` など任意のサブディレクトリにまとめておき、Markdown では相対パスで参照
 - 画像圧縮は TinyPNG や `squoosh-cli` で事前に行うと読み込みが速い
 - 共有用 OGP 画像は `ogp.png` をテンプレ化し、記事固有で置き換え
+
+## GitHub IaC
+
+- 実行フロー: `cd terraform && terraform init && terraform plan` で内容確認 → `terraform apply` で GitHub に反映

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Zenn CLI を使って記事作成や公開フローを効率化するための�
 ## GitHub IaC
 
 - `repo` スコープを持つ PAT を発行し `export GITHUB_TOKEN=$(gh auth token)` などで Terraform から利用
-- 初回は `terraform/terraform.tfvars.example` を `terraform/terraform.tfvars` にコピーし、自分の `github_owner` と `repository_name` を設定
+- 初回は `terraform/terraform.tfvars.example` を `terraform/terraform.tfvars` にコピーし、自分の `github_owner`・`repository_name`・`branch_pattern` を設定
 - 実行フロー: `cd terraform && terraform init && terraform plan` で内容確認 → `terraform apply` で GitHub に反映

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Zenn CLI を使って記事作成や公開フローを効率化するための�
 ## GitHub IaC
 
 - 実行フロー: `cd terraform && terraform init && terraform plan` で内容確認 → `terraform apply` で GitHub に反映
+
+- `export GITHUB_TOKEN=$(gh auth token)`

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.6.0"
+  constraints = "~> 6.3"
+  hashes = [
+    "h1:jPtUxZC/fwDeA+CPJoJHAhoDy/KhZdE7viycsWuXvgM=",
+    "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
+    "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",
+    "zh:4183e557a1dfd413dae90ca4bac37dbbe499eae5e923567371f768053f977800",
+    "zh:48b2979f88fb55cdb14b7e4c37c44e0dfbc21b7a19686ce75e339efda773c5c2",
+    "zh:5d803fb06625e0bcf83abb590d4235c117fa7f4aa2168fa3d5f686c41bc529ec",
+    "zh:6f1dd094cbab36363583cda837d7ca470bef5f8abf9b19f23e9cd8b927153498",
+    "zh:772edb5890d72b32868f9fdc0a9a1d4f4701d8e7f8acb37a7ac530d053c776e3",
+    "zh:798f443dbba6610431dcef832047f6917fb5a4e184a3a776c44e6213fb429cc6",
+    "zh:cc08dfcc387e2603f6dbaff8c236c1254185450d6cadd6bad92879fe7e7dbce9",
+    "zh:d5e2c8d7f50f91d6847ddce27b10b721bdfce99c1bbab42a68fa271337d73d63",
+    "zh:e69a0045440c706f50f84a84ff8b1df520ec9bf757de4b8f9959f2ed20c3f440",
+    "zh:efc5358573a6403cbea3a08a2fcd2407258ac083d9134c641bdcb578966d8bdf",
+    "zh:f627a255e5809ec2375f79949c79417847fa56b9e9222ea7c45a463eb663f137",
+    "zh:f7c02f762e4cf1de7f58bde520798491ccdd54a5bd52278d579c146d1d07d4f0",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,18 +8,18 @@ data "github_repository" "target" {
 
 resource "github_branch_protection" "main" {
   repository_id = data.github_repository.target.node_id
-  pattern        = var.branch_pattern
+  pattern       = var.branch_pattern
 
-  enforce_admins        = true
-  allows_force_pushes   = false
-  allows_deletions      = false
-  lock_branch           = false
-  require_signed_commits = true
+  enforce_admins                  = true
+  allows_force_pushes             = false
+  allows_deletions                = false
+  lock_branch                     = false
+  require_signed_commits          = true
   require_conversation_resolution = true
 
   required_pull_request_reviews {
-    dismiss_stale_reviews      = true
-    require_code_owner_reviews = false
-    required_approving_review_count = var.required_approving_review_count
+    dismiss_stale_reviews           = true
+    require_code_owner_reviews      = false
+    required_approving_review_count = 0
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ data "github_repository" "target" {
 
 resource "github_branch_protection" "main" {
   repository_id = data.github_repository.target.node_id
-  pattern        = "main"
+  pattern        = var.branch_pattern
 
   enforce_admins        = true
   allows_force_pushes   = false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,25 @@
+provider "github" {
+  owner = var.github_owner
+}
+
+data "github_repository" "target" {
+  full_name = "${var.github_owner}/${var.repository_name}"
+}
+
+resource "github_branch_protection" "main" {
+  repository_id = data.github_repository.target.node_id
+  pattern        = "main"
+
+  enforce_admins        = true
+  allows_force_pushes   = false
+  allows_deletions      = false
+  lock_branch           = false
+  require_signed_commits = true
+  require_conversation_resolution = true
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews      = true
+    require_code_owner_reviews = false
+    required_approving_review_count = var.required_approving_review_count
+  }
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,4 @@
+# Copy this file to terraform.tfvars or provide variables via CLI/environment.
+github_owner = "mkanetsuna"
+repository_name = "zenn-contents"
+# required_approving_review_count = 0

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,4 +1,4 @@
 # Copy this file to terraform.tfvars or provide variables via CLI/environment.
 github_owner = "mkanetsuna"
 repository_name = "zenn-contents"
-# required_approving_review_count = 0
+required_approving_review_count = 0

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,4 +1,0 @@
-# Copy this file to terraform.tfvars or provide variables via CLI/environment.
-github_owner = "mkanetsuna"
-repository_name = "zenn-contents"
-required_approving_review_count = 0

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,5 +1,4 @@
 # Copy this file to terraform.tfvars or provide variables via CLI/environment.
 github_owner = "your-github-handle"
 repository_name = "zenn-contents"
-required_approving_review_count = 0
 branch_pattern = "main"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy this file to terraform.tfvars or provide variables via CLI/environment.
+github_owner = "your-github-handle"
+repository_name = "zenn-contents"
+# required_approving_review_count = 0

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,4 +1,5 @@
 # Copy this file to terraform.tfvars or provide variables via CLI/environment.
 github_owner = "your-github-handle"
 repository_name = "zenn-contents"
-# required_approving_review_count = 0
+required_approving_review_count = 0
+branch_pattern = "main"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,9 +5,15 @@ variable "github_owner" {
 variable "repository_name" {
   description = "Repository name to apply branch protection to."
   type        = string
+  default     = "main"
 }
 
 variable "branch_pattern" {
   description = "Branch name pattern to apply protections to."
   type        = string
+}
+variable "branch_pattern" {
+  description = "Branch name pattern to apply protections to."
+  type        = string
+  default     = "main"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,9 +11,5 @@ variable "repository_name" {
 variable "branch_pattern" {
   description = "Branch name pattern to apply protections to."
   type        = string
-}
-variable "branch_pattern" {
-  description = "Branch name pattern to apply protections to."
-  type        = string
   default     = "main"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,13 +1,11 @@
 variable "github_owner" {
   description = "GitHub organization or user that owns the repository."
   type        = string
-  default     = "mkanetsuna"
 }
 
 variable "repository_name" {
   description = "Repository name to apply branch protection to."
   type        = string
-  default     = "zenn-contents"
 }
 
 variable "required_approving_review_count" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,7 +2,6 @@ variable "github_owner" {
   description = "GitHub organization or user that owns the repository."
   type        = string
 }
-
 variable "repository_name" {
   description = "Repository name to apply branch protection to."
   type        = string
@@ -11,5 +10,9 @@ variable "repository_name" {
 variable "required_approving_review_count" {
   description = "Number of approving reviews required before merging."
   type        = number
-  default     = 0
+}
+
+variable "branch_pattern" {
+  description = "Branch name pattern to apply protections to."
+  type        = string
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,17 @@
+variable "github_owner" {
+  description = "GitHub organization or user that owns the repository."
+  type        = string
+  default     = "mkanetsuna"
+}
+
+variable "repository_name" {
+  description = "Repository name to apply branch protection to."
+  type        = string
+  default     = "zenn-contents"
+}
+
+variable "required_approving_review_count" {
+  description = "Number of approving reviews required before merging."
+  type        = number
+  default     = 0
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,11 +7,6 @@ variable "repository_name" {
   type        = string
 }
 
-variable "required_approving_review_count" {
-  description = "Number of approving reviews required before merging."
-  type        = number
-}
-
 variable "branch_pattern" {
   description = "Branch name pattern to apply protections to."
   type        = string

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.3"
+    }
+  }
+}


### PR DESCRIPTION
Description:

- provision GitHub branch protection via new Terraform configuration (provider pins, variables, tfvars.example, lock file)

- wire devcontainer with Terraform tooling and extension support

- document Terraform workflow and PAT requirements in README

- ignore Terraform state and local tfvars artifacts in git

Verification: cd terraform && terraform fmt && terraform plan